### PR TITLE
fix(stemplayer-js): draghandle partially unset offset or duration when crossing region edges

### DIFF
--- a/elements/stemplayer-js/src/StemPlayer.js
+++ b/elements/stemplayer-js/src/StemPlayer.js
@@ -266,7 +266,10 @@ export class FcStemPlayer extends ResponsiveLitElement {
           currentPct: pct,
         });
 
-        this.style.setProperty('--stemplayer-progress', t);
+        this.style.setProperty(
+          '--stemplayer-progress',
+          Math.round(t * 100) / 100,
+        );
       });
     });
 
@@ -283,7 +286,10 @@ export class FcStemPlayer extends ResponsiveLitElement {
         currentPct: pct,
       });
 
-      this.style.setProperty('--stemplayer-progress', t);
+      this.style.setProperty(
+        '--stemplayer-progress',
+        Math.round(t * 100) / 100,
+      );
     });
 
     controller.on('duration', duration => {


### PR DESCRIPTION
Fixes an issue where the drag handle unsets when crossing region edges.

[Before](https://github.com/user-attachments/assets/db8ed0e5-e5c6-4f75-a058-20f1a3f31e86)

[After](https://github.com/user-attachments/assets/2da41569-00af-4004-a4d1-ed3b74936602)

Also economises on event handlers by tapping into the already existing handlers rather than creating additional ones for the edges.
