### PR TITLE
min-max region duration using events

### DIFF
--- a/elements/stemplayer-js/demo/max-duration-regions.html
+++ b/elements/stemplayer-js/demo/max-duration-regions.html
@@ -5,6 +5,7 @@
     <style>
       body {
         background-color: #333;
+        --stemplayer-js-region-btn-deselect-display: none;
       }
     </style>
   </head>
@@ -13,7 +14,7 @@
       import 'lit';
       import '../stemplayer.js';
     </script>
-    <stemplayer-js style="margin-right: 100px;" regions>
+    <stemplayer-js style="margin-right: 100px;" regions duration="5" offset="5">
       <stemplayer-js-controls
         label="Demo track"
         controls="label progress zoom loop"

--- a/elements/stemplayer-js/demo/max-duration-regions.html
+++ b/elements/stemplayer-js/demo/max-duration-regions.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        background-color: #333;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module">
+      import 'lit';
+      import '../stemplayer.js';
+    </script>
+    <stemplayer-js style="margin-right: 100px;" zoom="1.5" regions>
+      <stemplayer-js-controls
+        label="Demo track"
+        controls="label progress zoom loop"
+        slot="header"
+      ></stemplayer-js-controls>
+      <stemplayer-js-stem
+        label="Drums A"
+        src="assets/audio/106%20DRUMS%20A_02.5.m3u8"
+        waveform="assets/waveforms/106%20DRUMS%20A_02.5.json"
+        volume="1"
+      >
+      </stemplayer-js-stem>
+      <stemplayer-js-stem
+        id="stem-drums-b"
+        label="Drums B"
+        src="assets/audio/106%20DRUMS%20B_01.5.m3u8"
+        waveform="assets/waveforms/106%20DRUMS%20B_01.5.json"
+        muted="true"
+        volume="0.8"
+      ></stemplayer-js-stem>
+      <stemplayer-js-stem
+        label="Conga"
+        src="assets/audio/106%20CONGA_03.3.m3u8"
+        waveform="assets/waveforms/106%20CONGA_03.3.json"
+        volume="0.7"
+      ></stemplayer-js-stem>
+      <stemplayer-js-stem
+        label="Casaba"
+        src="assets/audio/106%20CABASA_04.3.m3u8"
+        waveform="assets/waveforms/106%20CABASA_04.3.json"
+        volume="0.4"
+        muted="true"
+      ></stemplayer-js-stem>
+      <stemplayer-js-stem
+        label="Bell"
+        src="assets/audio/106%20BELL_05.3.m3u8"
+        waveform="assets/waveforms/106%20BELL_05.3.json"
+        bg-color="green"
+        volume="0.5"
+      ></stemplayer-js-stem>
+      <stemplayer-js-stem
+        label="Drums A"
+        src="assets/audio/106%20DRUMS%20A_02.5-short.m3u8"
+        waveform="assets/waveforms/106%20DRUMS%20A_02.5-short.json"
+      >
+      </stemplayer-js-stem>
+    </stemplayer-js>
+
+
+
+    <script>
+      const stemplayer = document.querySelector('stemplayer-js');
+
+      stemplayer.addEventListener('peaks', (peaks) => {
+        console.log(peaks)
+      })
+
+      const maxDuration = 10
+
+      stemplayer.addEventListener('region:pre-update', (e) => {
+        const { duration, region, direction } = e.detail;
+
+        // if duration is too long
+        if (duration >= maxDuration) {
+          // prevent region to update further during dragging
+          e.preventDefault();
+
+          // when dragging from right to left + region too large, set the region to maxDuration while using the right as anchor
+          // this requires setting the offset based on the "end" time, minus maxDuration
+          if (direction === 'left') {
+            region.offset = region.offset + region.duration - maxDuration;
+          }
+
+          // set the region display duration to max
+          region.duration = maxDuration
+        }
+      })
+
+      stemplayer.addEventListener('region:change', (e) => {
+        const { duration } = e.detail;
+        if (duration > maxDuration) {
+          // set to max duration
+          stemplayer.duration = undefined; // unset to force update lifecycle behavior
+          stemplayer.duration = 10.0;
+        }
+      })
+
+      // eslint-disable-next-line no-unused-vars
+      function zoom(f) {
+        stemplayer.zoom += f
+        console.log(stemplayer.zoom)
+      }
+
+    </script>
+
+    <button onclick="zoom(0.5)">Zoom in</button>
+    <button onclick="zoom(-0.5)">Zoom out</button>
+  </body>
+</html>

--- a/elements/stemplayer-js/demo/min-duration-regions.html
+++ b/elements/stemplayer-js/demo/min-duration-regions.html
@@ -92,7 +92,7 @@
       stemplayer.addEventListener('region:change', (e) => {
         const { region } = e.detail;
 
-        if (isOutOfBounds) {
+        if (isOutOfBounds && region) {
           // set to region offset + duration .. unset first to force update lifecycle behavior
           stemplayer.offset = undefined;
           stemplayer.offset = region.offset;

--- a/elements/stemplayer-js/demo/min-duration-regions.html
+++ b/elements/stemplayer-js/demo/min-duration-regions.html
@@ -65,27 +65,27 @@
     <script>
       const stemplayer = document.querySelector('stemplayer-js');
 
-      const maxDuration = 5
+      const minDuration = 5
       let isOutOfBounds;
 
       stemplayer.addEventListener('region:pre-update', (e) => {
         const { duration, region, direction } = e.detail;
 
         // store reference to mark if drag update of region was prevented
-        isOutOfBounds = duration >= maxDuration;
+        isOutOfBounds = duration < minDuration;
 
         // if duration is too long
         if (isOutOfBounds) {
           // preventDefault stop region to update further during dragging
           e.preventDefault();
 
-          // when dragging from right to left + out of bounds, set the region to maxDuration while using the right as anchor. This requires setting the offset based on the "end" time, minus maxDuration
+          // when dragging from right to left + out of bounds, set the region to minDuration while using the right as anchor. This requires setting the offset based on the "end" time, minus minDuration
           if (direction === 'left') {
-            region.offset = region.offset + region.duration - maxDuration;
+            region.offset = region.offset + region.duration - minDuration;
           }
 
           // set the region display duration to max
-          region.duration = maxDuration
+          region.duration = minDuration
         }
       })
 
@@ -97,7 +97,7 @@
           stemplayer.offset = undefined;
           stemplayer.offset = region.offset;
           stemplayer.duration = undefined;
-          stemplayer.duration = maxDuration;
+          stemplayer.duration = minDuration;
         }
       })
     </script>

--- a/elements/stemplayer-js/src/Workspace.js
+++ b/elements/stemplayer-js/src/Workspace.js
@@ -122,6 +122,10 @@ export class Workspace extends ResponsiveLitElement {
           top: 0;
           width: 10px;
         }
+
+        fc-player-button[type='deselect'] {
+          display: var(--stemplayer-js-region-btn-deselect-display, block);
+        }
       `,
     ];
   }
@@ -146,6 +150,14 @@ export class Workspace extends ResponsiveLitElement {
       this.addEventListener('mouseout', e => this.#onMouseOut(e));
       this.#wheelEventHandler = e => this.#onHover(e);
       this.addEventListener('wheel', this.#wheelEventHandler);
+
+      // hide the deselect button if we are in a locked state
+      if (this.lockRegions) {
+        this.style.setProperty(
+          '--stemplayer-js-region-btn-deselect-display',
+          'none',
+        );
+      }
     }, 0);
   }
 
@@ -212,7 +224,6 @@ export class Workspace extends ResponsiveLitElement {
                 @mousedown=${e => e.stopPropagation()}
                 class="hRow w2"
                 type="deselect"
-                style="${this.lockRegions ? 'display:none' : ''}"
               ></fc-player-button>
             </div>
           </div>`
@@ -326,9 +337,12 @@ export class Workspace extends ResponsiveLitElement {
   #onDeselectClick(e) {
     e.stopPropagation();
     e.preventDefault();
+
     this.dispatchEvent(
       new CustomEvent('region:change', {
         detail: { offset: undefined, duration: undefined },
+        bubbles: true,
+        composed: true,
       }),
     );
   }


### PR DESCRIPTION
Adds an `region:pre-update` cancellable event which allows preventing updating of the regions area.

Added examples of how this can be used for enforcing min|max region duration length